### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "rotonda-macros"
 categories = ["network-programming"]
 description = "Procedural macros for the rotonda-store prefix store"
 homepage = "https://nlnetlabs.nl/projects/routing/rotonda/"
+repository = "https://github.com/NLnetLabs/rotonda-macros"
 keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 version = "0.3.1"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).