### PR TITLE
Release 0.4.0 rc0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Procedural macros for the rotonda-store prefix store"
 homepage = "https://nlnetlabs.nl/projects/routing/rotonda/"
 keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
-version = "0.3.1"
+version = "0.4.0-rc0"
 
 [lib]
 proc-macro = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.4.0-rc0
+
+Released 2024-06-12.
+
+Breaking Changes
+
+* remove MergeUpdate trait
+
+New
+
+* public API for best and backup path selection.
+* public API for searching and iterating paths for multi_uniq_ids.
+* public API for modifying local and global multi_uniq_ids ('mui').
+
 ## 0.3.1
 
 Released 2021-03-25.


### PR DESCRIPTION
## 0.4.0-rc0

Released 2024-06-12.

Breaking Changes

* remove MergeUpdate trait

New

* public API for best and backup path selection.
* public API for searching and iterating paths for multi_uniq_ids.
* public API for modifying local and global multi_uniq_ids ('mui').